### PR TITLE
Use newer version of aiohttp.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ description-file = "README.md"
 requires-python=">=3.8"
 requires=[
     "aiofiles == 0.6.0",
-    "aiohttp == 3.7.4",
+    "aiohttp == 3.11.18",
     "cmd2 == 1.5.0",
     "Jinja2 == 3.0.0",
     "ruamel.yaml == 0.17.17",


### PR DESCRIPTION
Old versions of aiohttp imported module cgi, which has been recently phased out and no longer comes with standard Python. This commit switches to the current version of aiohttp because it doesn't import cgi any more.

I have used this new build in production without issues (fingers crossed), so I think we're good.